### PR TITLE
ENYO-733: Default to building resolution-independent CSS.

### DIFF
--- a/tools/deploy.bat
+++ b/tools/deploy.bat
@@ -17,8 +17,8 @@ REM node location
 SET NODE=node.exe
 
 REM use node to invoke deploy.js with imported parameters
-ECHO %NODE% "%DEPLOY%" -T -s "%SRC%" -o "%SRC%\deploy -r" %*
-%NODE% "%DEPLOY%" -T -s "%SRC%" -o "%SRC%\deploy" -r %*
+ECHO %NODE% "%DEPLOY%" -T -s "%SRC%" -o "%SRC%\deploy" %*
+%NODE% "%DEPLOY%" -T -s "%SRC%" -o "%SRC%\deploy" %*
 IF ERRORLEVEL 1 GOTO err
 
 REM copy files and package if deploying to cordova webos

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -24,8 +24,8 @@ DEPLOY="$ENYO/tools/deploy.js"
 # check for node, but quietly
 if command -v node >/dev/null 2>&1; then
 	# use node to invoke deploy with imported parameters
-	echo "node $DEPLOY -T -s $SRC -o $SRC/deploy -r $@"
-	node "$DEPLOY" -T -s "$SRC" -o "$SRC/deploy" -r $@
+	echo "node $DEPLOY -T -s $SRC -o $SRC/deploy $@"
+	node "$DEPLOY" -T -s "$SRC" -o "$SRC/deploy" $@
 else
 	echo "No node found in path"
 	exit 1


### PR DESCRIPTION
### Issue
We want to build resolution-independent CSS by default.

### Fix
We no longer need to specify the resolution-independent flags when deploying this application, so we revert the earlier commit that added these flags. This PR is dependent on https://github.com/enyojs/enyo/pull/988.

Revert "ENYO-690: Use the resolution-independence switch."

This reverts commit 4bada314a19ebf7c9d0c00ac1dfbd2b45a1aabd0.