### PR TITLE
ENYO-952: Add reference to resolution-independent version of less.js.

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -9,7 +9,11 @@
 		<meta name="apple-mobile-web-app-capable" content="yes"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 		<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
-		<script src="enyo/tools/less.js"></script>
+		<!-- <script src="enyo/tools/less.js"></script> -->
+		<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+		<script src="enyo/tools/less-ri.js"></script>
 		<!-- enyo (debug) -->
 		<script src="enyo/enyo.js"></script>
 		<!-- application (debug) -->


### PR DESCRIPTION
### Issue
In adding a resolution-independent version of `less.js`, `less-ri.js`, via https://github.com/enyojs/enyo/pull/1026, we need to make bootplate-moonstone aware of this.

### Fix
Update `debug.html` with the appropriate documentation to utilize this feature. I decided to make `less-ri.js` the default, as this corresponds to the resolution-independent features that are present in the latest enyo and moonstone.

### Notes
In order to properly keep things in sync, once https://github.com/enyojs/enyo/pull/1026 has been integrated, the enyo submodule should be bumped to reference this. Alternatively, we can just wait until the next release is tagged.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>