### PR TITLE
ENYO-957: Only parse LESS files when minifying.

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -9,11 +9,7 @@
 		<meta name="apple-mobile-web-app-capable" content="yes"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 		<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
-		<!-- <script src="enyo/tools/less.js"></script> -->
-		<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
-		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
-		script is uncommented). -->
-		<script src="enyo/tools/less-ri.js"></script>
+		<script src="enyo/tools/less.js"></script>
 		<!-- enyo (debug) -->
 		<script src="enyo/enyo.js"></script>
 		<!-- application (debug) -->


### PR DESCRIPTION
### Issue
Based on the changes in https://github.com/enyojs/enyo/pull/1028, we no longer parse CSS for resolution-independence conversion.

### Fix
We revert the previous change we had made to support parsing of CSS in the browser.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>