### PR TITLE
Fixes ENYO-1140

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -13,7 +13,7 @@
 		<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-		<script src="enyo/tools/less-ri.js"></script>
+		<script src="enyo/tools/less.js" ri></script>
 		<!-- enyo (debug) -->
 		<script src="enyo/enyo.js"></script>
 		<!-- application (debug) -->


### PR DESCRIPTION
## Issue
We had to create a custom LESS build and bootstrap to optionally include the resolution independence code. With the changes to the bootstrap, we want to update bootplate to use those changes.

## Fix
Update script tag and bump enyo submodule.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)