### PR TITLE
ENYO-1795: Add documentation for configuration of resolution-independence plugin in browser.

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -8,7 +8,10 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=utf8"/>
 		<meta name="apple-mobile-web-app-capable" content="yes"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
-		<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+		<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS).
+			 Specify configuration for resolution-independence plugin via query string parameters i.e.
+			 <script src="enyo/tools/less.js" ri-params="baseSize=28,minUnitSize=0"></script>
+		-->
 		<script src="enyo/tools/less.js"></script>
 		<!-- enyo (debug) -->
 		<script src="enyo/enyo.js"></script>


### PR DESCRIPTION
### Issue
We are enabling the configuration of the resolution-independence plugin in the browser.

### Fix
This change requires https://github.com/enyojs/enyo/pull/1205 and is primarily a documentation update.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>